### PR TITLE
[#004]: 회원가입

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,13 +4,15 @@ import 'reflect-metadata';
 
 import homeRoutes from './src/routes/homeRoutes';
 import postRoutes from './src/routes/post/postRoutes';
+import userRoutes from './src/routes/user/userRoutes';
 
 import config from './config';
 import appDataSource from './src/data-source';
 
 const app = express();
 
-app.use(homeRoutes, postRoutes);
+app.use(express.json());
+app.use(homeRoutes, postRoutes, userRoutes);
 
 const { port } = config;
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "author": "황인우",
   "license": "ISC",
   "dependencies": {
+    "argon2": "^0.31.0",
     "express": "^4.18.2",
+    "express-validator": "^7.0.1",
     "mysql2": "^3.6.0",
     "reflect-metadata": "^0.1.13",
     "typeorm": "^0.3.17"

--- a/src/entities/user/User.js
+++ b/src/entities/user/User.js
@@ -1,22 +1,12 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import argon2 from 'argon2';
 
-@Entity('users')
-class User {
-  @PrimaryGeneratedColumn({
-    type: 'bigint',
-  }) id;
+export default class User {
+  constructor(email) {
+    this.email = email;
+    this.encodedPassword = '';
+  }
 
-  @Column({
-    type: 'varchar',
-    name: 'name',
-    length: 255,
-  }) name;
-
-  @Column({
-    type: 'varchar',
-    name: 'username',
-    length: 255,
-  }) username;
+  async changePassword(password) {
+    this.encodedPassword = await argon2.hash(password);
+  }
 }
-
-export default User;

--- a/src/entities/user/UserEntity.js
+++ b/src/entities/user/UserEntity.js
@@ -1,0 +1,42 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('users')
+class UserEntity {
+  @PrimaryGeneratedColumn({
+    type: 'bigint',
+  }) id = undefined;
+
+  @Column({
+    type: 'varchar',
+    name: 'name',
+    length: 255,
+  }) name = undefined;
+
+  @Column({
+    type: 'varchar',
+    name: 'email',
+    length: 255,
+  }) email = undefined;
+
+  @Column({
+    type: 'varchar',
+    name: 'password',
+    length: 255,
+  }) encodedPassword = undefined;
+
+  static create({
+    name,
+    email,
+    encodedPassword,
+  }) {
+    const userEntity = new UserEntity();
+
+    userEntity.name = name;
+    userEntity.email = email;
+    userEntity.encodedPassword = encodedPassword;
+
+    return userEntity;
+  }
+}
+
+export default UserEntity;

--- a/src/entities/user/UserEntity.js
+++ b/src/entities/user/UserEntity.js
@@ -8,12 +8,6 @@ class UserEntity {
 
   @Column({
     type: 'varchar',
-    name: 'name',
-    length: 255,
-  }) name = undefined;
-
-  @Column({
-    type: 'varchar',
     name: 'email',
     length: 255,
   }) email = undefined;

--- a/src/exceptions/signup/InvalidSignUpInput.js
+++ b/src/exceptions/signup/InvalidSignUpInput.js
@@ -1,0 +1,5 @@
+export default class InvalidSignUpInput extends Error {
+  constructor() {
+    super('유효하지 않은 이메일 혹은 비밀번호입니다.');
+  }
+}

--- a/src/repositories/PostRepository.js
+++ b/src/repositories/PostRepository.js
@@ -16,7 +16,7 @@ export default class PostRepository {
       .select('posts.id', 'id')
       .addSelect('posts.title', 'title')
       .addSelect('users.id', 'userId')
-      .addSelect('users.name', 'authorName')
+      .addSelect('users.email', 'userEmail')
       .leftJoin(UserEntity, 'users', 'users.id = posts.user_id')
       .getRawMany();
 
@@ -29,10 +29,10 @@ export default class PostRepository {
     const postDto = await postRepository
       .createQueryBuilder('posts')
       .select('posts.id', 'id')
-      .addSelect('users.id', 'userId')
-      .addSelect('users.name', 'authorName')
       .addSelect('posts.title', 'title')
       .addSelect('posts.description_text', 'descriptionText')
+      .addSelect('users.id', 'userId')
+      .addSelect('users.email', 'userEmail')
       .leftJoin(UserEntity, 'users', 'users.id = posts.user_id')
       .where('posts.id = :postId', { postId })
       .getRawOne();

--- a/src/repositories/PostRepository.js
+++ b/src/repositories/PostRepository.js
@@ -3,7 +3,7 @@
 import appDataSource from '../data-source';
 
 import Post from '../entities/post/Post';
-import User from '../entities/user/User';
+import UserEntity from '../entities/user/UserEntity';
 
 import PostNotFound from '../exceptions/post/PostNotFound';
 
@@ -17,7 +17,7 @@ export default class PostRepository {
       .addSelect('posts.title', 'title')
       .addSelect('users.id', 'userId')
       .addSelect('users.name', 'authorName')
-      .leftJoin(User, 'users', 'users.id = posts.user_id')
+      .leftJoin(UserEntity, 'users', 'users.id = posts.user_id')
       .getRawMany();
 
     return postsDto;
@@ -33,7 +33,7 @@ export default class PostRepository {
       .addSelect('users.name', 'authorName')
       .addSelect('posts.title', 'title')
       .addSelect('posts.description_text', 'descriptionText')
-      .leftJoin(User, 'users', 'users.id = posts.user_id')
+      .leftJoin(UserEntity, 'users', 'users.id = posts.user_id')
       .where('posts.id = :postId', { postId })
       .getRawOne();
 

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -1,0 +1,25 @@
+/* eslint-disable class-methods-use-this */
+
+import appDataSource from '../data-source';
+import UserEntity from '../entities/user/UserEntity';
+
+export default class UserRepository {
+  async save({
+    email,
+    encodedPassword,
+  }) {
+    const userRepository = appDataSource.getRepository(UserEntity);
+
+    const userEntity = UserEntity.create({
+      name: 'default',
+      email,
+      encodedPassword,
+    });
+
+    const savedUserEntity = await userRepository.save(userEntity);
+
+    return savedUserEntity.id;
+  }
+}
+
+export const userRepository = new UserRepository();

--- a/src/routes/post/postRoutes.test.js
+++ b/src/routes/post/postRoutes.test.js
@@ -33,19 +33,19 @@ describe('postRoutes', () => {
       {
         id: 1,
         userId: 22,
-        authorName: '노승준',
+        userEmail: 'seungjjun@naver.com',
         title: '제목 1',
       },
       {
         id: 2,
         userId: 22,
-        authorName: '노승준',
+        userEmail: 'seungjjun@naver.com',
         title: '제목 22',
       },
       {
         id: 3,
         userId: 5,
-        authorName: '오진욱',
+        userEmail: 'jingwook@gmail.com',
         title: '제목 3333',
       },
     ];
@@ -71,10 +71,10 @@ describe('postRoutes', () => {
     context('post가 존재하는 경우', () => {
       const postDto = {
         id: 1,
-        userId: 22,
-        authorName: '노승준',
         title: '제목 111',
         descriptionText: '내용 1111',
+        userId: 22,
+        userEmail: 'seungjjun@naver.com',
       };
 
       beforeEach(() => {

--- a/src/routes/user/userRoutes.js
+++ b/src/routes/user/userRoutes.js
@@ -1,0 +1,46 @@
+import express from 'express';
+
+import { body, validationResult } from 'express-validator';
+
+import { signUpService } from '../../services/user/SignUpService';
+
+import InvalidSignUpInput from '../../exceptions/signup/InvalidSignUpInput';
+
+const router = express.Router();
+
+const has = (array) => array.length > 0;
+
+router.post(
+  '/users',
+  [
+    body('email').contains('@'),
+    body('password').isLength({ min: 8 }),
+  ],
+  async (request, response) => {
+    try {
+      const { errors } = validationResult(request);
+
+      if (has(errors)) {
+        throw new InvalidSignUpInput();
+      }
+
+      const signUpResultDto = await signUpService.signUp(request.body);
+
+      response.status(201)
+        .type('application/json')
+        .send(signUpResultDto);
+    } catch (error) {
+      if (error instanceof InvalidSignUpInput) {
+        response.status(400)
+          .type('text/html')
+          .send(error.message);
+      } else {
+        response.status(500)
+          .type('text/html')
+          .send('Internal Server Error');
+      }
+    }
+  },
+);
+
+export default router;

--- a/src/routes/user/userRoutes.test.js
+++ b/src/routes/user/userRoutes.test.js
@@ -1,0 +1,104 @@
+import request from 'supertest';
+
+import context from 'jest-plugin-context';
+
+import server from '../../../app';
+
+jest.mock('reflect-metadata', () => jest.fn());
+jest.mock('../../data-source', () => ({
+  initialize: jest.fn(),
+}));
+
+const signUp = jest.fn();
+
+jest.mock(
+  '../../services/user/SignUpService',
+  () => ({
+    signUpService: {
+      signUp: () => signUp(),
+    },
+  }),
+);
+
+describe('userRoutes', () => {
+  afterAll(() => {
+    server.close();
+  });
+
+  context('POST /users', () => {
+    let signUpRequestDto;
+
+    beforeEach(() => {
+      signUp.mockClear();
+    });
+
+    context('email, password가 올바르게 주어진 경우', () => {
+      const signUpResultDto = { userId: 1 };
+
+      beforeEach(() => {
+        signUpRequestDto = {
+          email: 'hsjkdss228@naver.com',
+          password: 'Password!1',
+        };
+        signUp.mockReturnValue(signUpResultDto);
+      });
+
+      it('생성된 User Entity의 id 응답을 반환', (done) => {
+        request(server).post('/users')
+          .accept('application/json')
+          .send(signUpRequestDto)
+          .expect(201)
+          .expect('Content-Type', /application\/json/)
+          .expect(signUpResultDto)
+          .end(() => {
+            expect(signUp).toBeCalled();
+            done();
+          });
+      });
+    });
+
+    context('email이 올바르지 않은 경우', () => {
+      beforeEach(() => {
+        signUpRequestDto = {
+          email: 'hsjkdss228',
+          password: 'Password!1',
+        };
+      });
+
+      it('InvalidSignUpInput 예외 응답을 반환', (done) => {
+        request(server).post('/users')
+          .accept('application/json')
+          .send(signUpRequestDto)
+          .expect(400)
+          .expect('Content-Type', /text\/html/)
+          .expect('유효하지 않은 이메일 혹은 비밀번호입니다.')
+          .end(() => {
+            expect(signUp).not.toBeCalled();
+            done();
+          });
+      });
+    });
+
+    context('password가 올바르지 않은 경우', () => {
+      beforeEach(() => {
+        signUpRequestDto = {
+          email: 'hsjkdss228@naver.com',
+          password: 'Pwd!1',
+        };
+      });
+
+      it('InvalidSignUpInput 예외 응답을 반환', (done) => {
+        request(server).post('/users')
+          .accept('application/json')
+          .send(signUpRequestDto)
+          .expect(400)
+          .expect('Content-Type', /text\/html/)
+          .expect('유효하지 않은 이메일 혹은 비밀번호입니다.')
+          .end(() => {
+            expect(signUp).not.toBeCalled();
+            done();
+          });
+      });
+    });
+  });
+});

--- a/src/services/user/SignUpService.js
+++ b/src/services/user/SignUpService.js
@@ -1,0 +1,22 @@
+/* eslint-disable class-methods-use-this */
+
+import { userRepository } from '../../repositories/UserRepository';
+
+import User from '../../entities/user/User';
+
+export default class SignUpService {
+  async signUp({
+    email,
+    password,
+  }) {
+    const user = new User(email);
+
+    await user.changePassword(password);
+
+    const userId = await userRepository.save(user);
+
+    return { userId };
+  }
+}
+
+export const signUpService = new SignUpService();

--- a/src/services/user/SignUpService.test.js
+++ b/src/services/user/SignUpService.test.js
@@ -1,0 +1,40 @@
+import context from 'jest-plugin-context';
+import SignUpService from './SignUpService';
+
+const save = jest.fn();
+
+jest.mock(
+  '../../repositories/UserRepository',
+  () => ({
+    userRepository: {
+      save: () => save(),
+    },
+  }),
+);
+
+let signUpService;
+
+describe('SignUpService', () => {
+  beforeEach(() => {
+    signUpService = new SignUpService();
+  });
+
+  context('회원가입 정보가 전달되면', () => {
+    const userId = 1;
+
+    beforeEach(() => {
+      save.mockReturnValue(userId);
+    });
+
+    it('User Entity를 생성해 저장, 생성된 id를 DTO에 포함시켜 반환', async () => {
+      const signUpRequestDto = {
+        email: 'hsjkdss228@naver.com',
+        password: 'Password!1',
+      };
+
+      const signUpResultDto = await signUpService.signUp(signUpRequestDto);
+
+      expect(signUpResultDto).toStrictEqual({ userId });
+    });
+  });
+});


### PR DESCRIPTION
- userRoutes
  - POST /users
  - 요청 본문이 application/json 타입으로 전달되는 경우, 요청 본문을 변환하기 위해 app.js에서 express.json을 use
  - express-validator 의존성 추가
    - POST /users 미들웨어에서 요청 본문에 대해 유효성 검사
    - email: '\@' 포함 - password: 8자 이상
  - 생성된 User Entity의 id를 응답으로 반환
- SignUpService
  - User Model 생성
    - argon2 의존성 추가
    - password 해싱
  - 생성된 User를 userRepository에 전달
- UserRepository
  - UserEntity 생성 후 영속화
  - 비즈니스 로직 처리를 위한 Model과 영속화를 위한 Entity 분리