### PR TITLE
[#post-2]: PostNotFound 내 사용되지 않는 field 삭제

### DIFF
--- a/src/exceptions/post/PostNotFound.js
+++ b/src/exceptions/post/PostNotFound.js
@@ -1,6 +1,5 @@
 export default class PostNotFound extends Error {
   constructor() {
     super('존재하지 않는 게시글입니다.');
-    this.name = 'PostNotFound';
   }
 }


### PR DESCRIPTION
- 삭제된 field: name
- Exception의 이름을 직접적으로 사용하지 않고 있음