### PR TITLE
[#006]: 게시글 생성

### DIFF
--- a/src/entities/post/Post.js
+++ b/src/entities/post/Post.js
@@ -1,0 +1,13 @@
+export default class Post {
+  constructor({
+    id = null,
+    userId,
+    title,
+    descriptionText,
+  }) {
+    this.id = id;
+    this.userId = userId;
+    this.title = title;
+    this.descriptionText = descriptionText;
+  }
+}

--- a/src/entities/post/PostEntity.js
+++ b/src/entities/post/PostEntity.js
@@ -1,7 +1,7 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity('posts')
-class Post {
+class PostEntity {
   @PrimaryGeneratedColumn({
     type: 'bigint',
   }) id = undefined;
@@ -22,6 +22,20 @@ class Post {
     name: 'description_text',
     length: 4095,
   }) descriptionText = undefined;
+
+  static create({
+    userId,
+    title,
+    descriptionText,
+  }) {
+    const postEntity = new PostEntity();
+
+    postEntity.userId = userId;
+    postEntity.title = title;
+    postEntity.descriptionText = descriptionText;
+
+    return postEntity;
+  }
 }
 
-export default Post;
+export default PostEntity;

--- a/src/middlewares/authenticationMiddleware.js
+++ b/src/middlewares/authenticationMiddleware.js
@@ -1,0 +1,18 @@
+import { jwtUtil } from '../utils/JwtUtil';
+
+const authenticationMiddleware = (request, response, next) => {
+  try {
+    const { authorization } = request.headers;
+    const accessToken = authorization.substring('Bearer '.length);
+
+    const userId = jwtUtil.decode(accessToken);
+    request.userId = userId;
+    next();
+  } catch (error) {
+    response.status(400)
+      .type('text/html')
+      .send('Access Token이 없거나 잘못되었습니다.');
+  }
+};
+
+export default authenticationMiddleware;

--- a/src/repositories/PostRepository.js
+++ b/src/repositories/PostRepository.js
@@ -43,6 +43,22 @@ export default class PostRepository {
 
     return postDto;
   }
+
+  async save(post) {
+    const postRepository = appDataSource.getRepository(PostEntity);
+
+    const { userId, title, descriptionText } = post;
+
+    const postEntity = PostEntity.create({
+      userId,
+      title,
+      descriptionText,
+    });
+
+    const { id } = await postRepository.save(postEntity);
+
+    return id;
+  }
 }
 
 export const postRepository = new PostRepository();

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -1,14 +1,21 @@
 /* eslint-disable class-methods-use-this */
 
 import appDataSource from '../data-source';
-import User from '../entities/user/User';
+
 import UserEntity from '../entities/user/UserEntity';
 
+import User from '../entities/user/User';
+
 export default class UserRepository {
-  async findBy(email) {
+  async findBy({
+    userId = null,
+    email = null,
+  }) {
     const userRepository = appDataSource.getRepository(UserEntity);
 
-    const userEntity = await userRepository.findOneBy({ email });
+    const userEntity = userId
+      ? await userRepository.findOneBy({ id: userId })
+      : await userRepository.findOneBy({ email });
 
     return !userEntity ? null : new User({
       id: userEntity.id,

--- a/src/routes/post/postRoutes.js
+++ b/src/routes/post/postRoutes.js
@@ -1,7 +1,12 @@
 import express from 'express';
 
+import authenticationMiddleware from '../../middlewares/authenticationMiddleware';
+
 import { postRepository } from '../../repositories/PostRepository';
+import { createPostService } from '../../services/post/CreatePostService';
+
 import PostNotFound from '../../exceptions/post/PostNotFound';
+import UserNotFound from '../../exceptions/user/UserNotFound';
 
 const router = express.Router();
 
@@ -32,5 +37,35 @@ router.get('/posts/:postId', async (request, response) => {
     }
   }
 });
+
+router.post(
+  '/posts',
+  authenticationMiddleware,
+  async (request, response) => {
+    const { userId } = request;
+
+    try {
+      const createPostResultDto = await createPostService
+        .createPost({
+          userId,
+          createPostRequestDto: request.body,
+        });
+
+      response.status(201)
+        .type('application/json')
+        .send(createPostResultDto);
+    } catch (error) {
+      if (error instanceof UserNotFound) {
+        response.status(404)
+          .type('text/html')
+          .send(error.message);
+      } else {
+        response.status(500)
+          .type('text/html')
+          .send('Internal Server Error');
+      }
+    }
+  },
+);
 
 export default router;

--- a/src/services/post/CreatePostService.js
+++ b/src/services/post/CreatePostService.js
@@ -1,0 +1,35 @@
+/* eslint-disable class-methods-use-this */
+
+import { userRepository } from '../../repositories/UserRepository';
+import { postRepository } from '../../repositories/PostRepository';
+
+import Post from '../../entities/post/Post';
+
+import UserNotFound from '../../exceptions/user/UserNotFound';
+
+export default class CreatePostService {
+  async createPost({
+    userId,
+    createPostRequestDto,
+  }) {
+    const user = await userRepository.findBy({ userId });
+
+    if (!user) {
+      throw new UserNotFound();
+    }
+
+    const { title, descriptionText } = createPostRequestDto;
+
+    const post = new Post({
+      userId,
+      title,
+      descriptionText,
+    });
+
+    const postId = await postRepository.save(post);
+
+    return { postId };
+  }
+}
+
+export const createPostService = new CreatePostService();

--- a/src/services/post/CreatePostService.test.js
+++ b/src/services/post/CreatePostService.test.js
@@ -1,0 +1,85 @@
+import context from 'jest-plugin-context';
+
+import CreatePostService from './CreatePostService';
+
+import User from '../../entities/user/User';
+
+import UserNotFound from '../../exceptions/user/UserNotFound';
+
+const findBy = jest.fn();
+
+jest.mock(
+  '../../repositories/UserRepository',
+  () => ({
+    userRepository: {
+      findBy: () => findBy(),
+    },
+  }),
+);
+
+const save = jest.fn();
+
+jest.mock(
+  '../../repositories/PostRepository',
+  () => ({
+    postRepository: {
+      save: () => save(),
+    },
+  }),
+);
+
+let createPostService;
+
+describe('CreatePostService', () => {
+  beforeEach(() => {
+    createPostService = new CreatePostService();
+  });
+
+  const createPostRequestDto = {
+    title: '제목 11111111',
+    descriptionText: '내용 @@@@@@@@@@@@',
+  };
+
+  context('createPost', () => {
+    beforeEach(() => {
+      findBy.mockClear();
+      save.mockClear();
+    });
+
+    context('정상적인 userId가 주어진 경우', () => {
+      const userId = 135;
+      const user = new User({
+        id: userId,
+        email: 'hsjkdss228@naver.com',
+      });
+      const postId = 12;
+
+      beforeEach(() => {
+        findBy.mockReturnValue(user);
+        save.mockReturnValue(postId);
+      });
+
+      it('생성된 Post의 id를 DTO에 포함해 반환', async () => {
+        const createPostResultDto = await createPostService
+          .createPost({
+            userId,
+            createPostRequestDto,
+          });
+
+        expect(createPostResultDto).toStrictEqual({ postId });
+      });
+    });
+
+    context('사용자가 존재하지 않는 경우', () => {
+      beforeEach(() => {
+        findBy.mockReturnValue(null);
+      });
+
+      it('UserNotFound 예외를 발생', () => {
+        expect(async () => {
+          await createPostService.createPost(createPostRequestDto);
+        }).rejects.toThrow(UserNotFound);
+      });
+    });
+  });
+});

--- a/src/services/session/LoginService.js
+++ b/src/services/session/LoginService.js
@@ -11,7 +11,7 @@ export default class LoginService {
     email,
     password,
   }) {
-    const user = await userRepository.findBy(email);
+    const user = await userRepository.findBy({ email });
 
     if (!user) {
       throw new UserNotFound();

--- a/src/utils/JwtUtil.js
+++ b/src/utils/JwtUtil.js
@@ -16,7 +16,11 @@ export default class JwtUtil {
   }
 
   decode(accessToken) {
-    return null;
+    const { userId } = jwt.verify(
+      accessToken,
+      secret,
+    );
+    return userId;
   }
 }
 


### PR DESCRIPTION
- postRoutes
  - POST /posts
  - authenticationMiddleware로부터 전달받은 userId, 요청 본문을 전달
  - 생성된 게시글의 id를 반환
- authenticationMiddleware
  - Header로 전달된 Authorization 값을 파싱해 Access Token 획득
  - Access Token을 디코딩해 userId 획득
  - Authorization에 문제가 있거나 디코딩 실패 시 예외처리
  - userId를 request에 전달
- CreatePostService
  - userId에 해당하는 User Entity가 존재하지 않을 시 예외처리
  - Post 생성 후 영속화
- Repository
  - UserRepository
    - findBy({ userId })
    - findBy에 전달되는 인자에 따라 다른 조건으로 쿼리 수행 (userId or email)
  - PostRepository
    - save(post)