### PR TITLE
[#002_3]: 게시글 목록 조회 페이지네이션

### DIFF
--- a/src/entities/post/PostEntity.js
+++ b/src/entities/post/PostEntity.js
@@ -26,6 +26,7 @@ class PostEntity {
   @Column({
     type: 'boolean',
     name: 'deleted',
+    default: false,
   }) deleted = undefined;
 
   static create({

--- a/src/exceptions/pagination/InvalidPageOrCount.js
+++ b/src/exceptions/pagination/InvalidPageOrCount.js
@@ -1,0 +1,5 @@
+export default class InvalidPageOrCount extends Error {
+  constructor() {
+    super('잘못된 페이지 또는 게시글 개수 값입니다.');
+  }
+}

--- a/src/exceptions/pagination/PageOrCountIsEmpty.js
+++ b/src/exceptions/pagination/PageOrCountIsEmpty.js
@@ -1,0 +1,5 @@
+export default class PageOrCountIsEmpty extends Error {
+  constructor() {
+    super('페이지 또는 게시글 개수 값이 주어지지 않았습니다.');
+  }
+}

--- a/src/middlewares/paginationMiddleware.js
+++ b/src/middlewares/paginationMiddleware.js
@@ -1,0 +1,32 @@
+import PageOrCountIsEmpty from '../exceptions/pagination/PageOrCountIsEmpty';
+import InvalidPageOrCount from '../exceptions/pagination/InvalidPageOrCount';
+
+const isNumeric = (input) => /^\d+$/.test(input);
+
+const paginationMiddleware = (request, response, next) => {
+  try {
+    const { page, count } = request.query;
+
+    if (!page || !count) {
+      throw new PageOrCountIsEmpty();
+    }
+
+    if (!isNumeric(page) || !isNumeric(count)) {
+      throw new InvalidPageOrCount();
+    }
+
+    next();
+  } catch (error) {
+    if (error instanceof PageOrCountIsEmpty || InvalidPageOrCount) {
+      response.status(400)
+        .type('text/html')
+        .send(error.message);
+    } else {
+      response.status(500)
+        .type('text/html')
+        .send('Internal Server Error');
+    }
+  }
+};
+
+export default paginationMiddleware;

--- a/src/routes/post/postRoutes.js
+++ b/src/routes/post/postRoutes.js
@@ -12,13 +12,20 @@ import PostIsDeleted from '../../exceptions/post/PostIsDeleted';
 import UserNotFound from '../../exceptions/user/UserNotFound';
 import UserNotCreatedPost from '../../exceptions/post/UserNotCreatedPost';
 import PostAlreadyDeleted from '../../exceptions/post/PostAlreadyDeleted';
+import paginationMiddleware from '../../middlewares/paginationMiddleware';
 
 const router = express.Router();
 
 router.get(
   '/posts',
-  async (_, response) => {
-    const postsDto = await postRepository.find();
+  paginationMiddleware,
+  async (request, response) => {
+    const { page, count } = request.query;
+
+    const postsDto = await postRepository.find({
+      page: Number(page),
+      count: Number(count),
+    });
 
     response.type('application/json')
       .send(postsDto);

--- a/src/routes/post/postRoutes.test.js
+++ b/src/routes/post/postRoutes.test.js
@@ -56,37 +56,74 @@ describe('postRoutes', () => {
   });
 
   context('GET /posts', () => {
-    const postsDto = [
-      {
-        id: 1,
-        userId: 22,
-        userEmail: 'seungjjun@naver.com',
-        title: '제목 1',
-      },
-      {
-        id: 2,
-        userId: 22,
-        userEmail: 'seungjjun@naver.com',
-        title: '제목 22',
-      },
-      {
-        id: 3,
-        userId: 5,
-        userEmail: 'jingwook@gmail.com',
-        title: '제목 3333',
-      },
-    ];
-
     beforeEach(() => {
-      find.mockReturnValue(postsDto);
+      find.mockClear();
     });
 
-    it('postsDto 응답을 반환', (done) => {
-      request(server).get('/posts')
-        .expect(200)
-        .expect('Content-Type', /application\/json/)
-        .expect(postsDto)
-        .end(done);
+    const postsDto = {
+      posts: [
+        {
+          id: 1,
+          title: '제목 1',
+          userId: 22,
+          userEmail: 'seungjjun@naver.com',
+        },
+        {
+          id: 2,
+          title: '제목 22',
+          userId: 22,
+          userEmail: 'seungjjun@naver.com',
+        },
+        {
+          id: 3,
+          title: '제목 3333',
+          userId: 5,
+          userEmail: 'jingwook@gmail.com',
+        },
+      ],
+      totalCount: 15,
+    };
+
+    context('페이지, 게시글 개수 쿼리 파라미터가 정상적으로 주어지는 경우', () => {
+      beforeEach(() => {
+        find.mockReturnValue(postsDto);
+      });
+
+      it('postsDto 응답을 반환', (done) => {
+        request(server).get('/posts')
+          .query({
+            page: '1',
+            count: '3',
+          })
+          .expect(200)
+          .expect('Content-Type', /application\/json/)
+          .expect(postsDto)
+          .end(done);
+      });
+    });
+
+    context('페이지, 게시글 개수 쿼리 파라미터가 주어지지 않은 경우', () => {
+      it('400 미들웨어 예외 응답을 반환', (done) => {
+        request(server).get('/posts')
+          .expect(400)
+          .expect('Content-Type', /text\/html/)
+          .expect('페이지 또는 게시글 개수 값이 주어지지 않았습니다.')
+          .end(done);
+      });
+    });
+
+    context('잘못된 페이지, 게시글 개수 쿼리 파라미터가 주어진 경우', () => {
+      it('400 미들웨어 예외 응답을 반환', (done) => {
+        request(server).get('/posts')
+          .query({
+            page: '1페이지',
+            count: '3개',
+          })
+          .expect(400)
+          .expect('Content-Type', /text\/html/)
+          .expect('잘못된 페이지 또는 게시글 개수 값입니다.')
+          .end(done);
+      });
     });
   });
 


### PR DESCRIPTION
- GET /posts 요청 쿼리 파라미터 추가
  - page: 목록에서 조회할 페이지
  - count: 페이지에서 조회할 게시글들의 개수
- paginationMiddleware 추가
  - 쿼리 파라미터 유효성 검사 (숫자만 허용)
- PostRepository
  - skip(), take() 메서드를 통한 페이지네이션 적용
  - getRawMany() 방식의 특정 Column 쿼리 시에는 페이지네이션이 적용되지 않는 이슈가 있었음
  - 전체 Entity를 모두 쿼리한 뒤, 각 Entity에서 특정 요소만을 이용해 DTO를 재생성하는 방식으로 DTO 생성 방식 변경