### PR TITLE
routes 디렉터리 구조 변경

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,9 +5,9 @@ import cors from 'cors';
 import 'reflect-metadata';
 
 import homeRoutes from './src/routes/homeRoutes';
-import postRoutes from './src/routes/post/postRoutes';
-import userRoutes from './src/routes/user/userRoutes';
-import sessionRoutes from './src/routes/session/sessionRoutes';
+import postRoutes from './src/routes/postRoutes';
+import userRoutes from './src/routes/userRoutes';
+import sessionRoutes from './src/routes/sessionRoutes';
 
 import config from './config';
 import appDataSource from './src/data-source';

--- a/src/routes/postRoutes.js
+++ b/src/routes/postRoutes.js
@@ -1,18 +1,18 @@
 import express from 'express';
 
-import authenticationMiddleware from '../../middlewares/authenticationMiddleware';
+import authenticationMiddleware from '../middlewares/authenticationMiddleware';
 
-import { postRepository } from '../../repositories/PostRepository';
-import { createPostService } from '../../services/post/CreatePostService';
-import { modifyPostService } from '../../services/post/ModifyPostService';
-import { deletePostService } from '../../services/post/DeletePostService';
+import { postRepository } from '../repositories/PostRepository';
+import { createPostService } from '../services/post/CreatePostService';
+import { modifyPostService } from '../services/post/ModifyPostService';
+import { deletePostService } from '../services/post/DeletePostService';
 
-import PostNotFound from '../../exceptions/post/PostNotFound';
-import PostIsDeleted from '../../exceptions/post/PostIsDeleted';
-import UserNotFound from '../../exceptions/user/UserNotFound';
-import UserNotCreatedPost from '../../exceptions/post/UserNotCreatedPost';
-import PostAlreadyDeleted from '../../exceptions/post/PostAlreadyDeleted';
-import paginationMiddleware from '../../middlewares/paginationMiddleware';
+import PostNotFound from '../exceptions/post/PostNotFound';
+import PostIsDeleted from '../exceptions/post/PostIsDeleted';
+import UserNotFound from '../exceptions/user/UserNotFound';
+import UserNotCreatedPost from '../exceptions/post/UserNotCreatedPost';
+import PostAlreadyDeleted from '../exceptions/post/PostAlreadyDeleted';
+import paginationMiddleware from '../middlewares/paginationMiddleware';
 
 const router = express.Router();
 

--- a/src/routes/postRoutes.test.js
+++ b/src/routes/postRoutes.test.js
@@ -2,17 +2,17 @@ import request from 'supertest';
 
 import context from 'jest-plugin-context';
 
-import server from '../../../app';
+import server from '../../app';
 
-import { jwtUtil } from '../../utils/JwtUtil';
+import { jwtUtil } from '../utils/JwtUtil';
 
-import PostNotFound from '../../exceptions/post/PostNotFound';
-import UserNotFound from '../../exceptions/user/UserNotFound';
-import UserNotCreatedPost from '../../exceptions/post/UserNotCreatedPost';
-import PostAlreadyDeleted from '../../exceptions/post/PostAlreadyDeleted';
+import PostNotFound from '../exceptions/post/PostNotFound';
+import UserNotFound from '../exceptions/user/UserNotFound';
+import UserNotCreatedPost from '../exceptions/post/UserNotCreatedPost';
+import PostAlreadyDeleted from '../exceptions/post/PostAlreadyDeleted';
 
 jest.mock('reflect-metadata', () => jest.fn());
-jest.mock('../../data-source', () => ({
+jest.mock('../data-source', () => ({
   initialize: jest.fn(),
 }));
 
@@ -20,7 +20,7 @@ const find = jest.fn();
 const findOneDtoBy = jest.fn();
 
 jest.mock(
-  '../../repositories/PostRepository',
+  '../repositories/PostRepository',
   () => ({
     postRepository: {
       find: () => find(),
@@ -32,7 +32,7 @@ jest.mock(
 const createPost = jest.fn();
 
 jest.mock(
-  '../../services/post/CreatePostService',
+  '../services/post/CreatePostService',
   () => ({
     createPostService: {
       createPost: () => createPost(),
@@ -43,7 +43,7 @@ jest.mock(
 const modifyPost = jest.fn();
 
 jest.mock(
-  '../../services/post/ModifyPostService',
+  '../services/post/ModifyPostService',
   () => ({
     modifyPostService: {
       modifyPost: () => modifyPost(),
@@ -54,7 +54,7 @@ jest.mock(
 const deletePost = jest.fn();
 
 jest.mock(
-  '../../services/post/DeletePostService',
+  '../services/post/DeletePostService',
   () => ({
     deletePostService: {
       deletePost: () => deletePost(),

--- a/src/routes/sessionRoutes.js
+++ b/src/routes/sessionRoutes.js
@@ -2,11 +2,11 @@ import express from 'express';
 
 import { body, validationResult } from 'express-validator';
 
-import { loginService } from '../../services/session/LoginService';
+import { loginService } from '../services/session/LoginService';
 
-import EmptyLoginInput from '../../exceptions/login/EmptyLoginInput';
-import UserNotFound from '../../exceptions/user/UserNotFound';
-import IncorrectPassword from '../../exceptions/login/IncorrectPassword';
+import EmptyLoginInput from '../exceptions/login/EmptyLoginInput';
+import UserNotFound from '../exceptions/user/UserNotFound';
+import IncorrectPassword from '../exceptions/login/IncorrectPassword';
 
 const router = express.Router();
 

--- a/src/routes/sessionRoutes.test.js
+++ b/src/routes/sessionRoutes.test.js
@@ -2,17 +2,17 @@ import request from 'supertest';
 
 import context from 'jest-plugin-context';
 
-import server from '../../../app';
+import server from '../../app';
 
 jest.mock('reflect-metadata', () => jest.fn());
-jest.mock('../../data-source', () => ({
+jest.mock('../data-source', () => ({
   initialize: jest.fn(),
 }));
 
 const login = jest.fn();
 
 jest.mock(
-  '../../services/session/LoginService',
+  '../services/session/LoginService',
   () => ({
     loginService: {
       login: () => login(),

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -2,9 +2,9 @@ import express from 'express';
 
 import { body, validationResult } from 'express-validator';
 
-import { signUpService } from '../../services/user/SignUpService';
+import { signUpService } from '../services/user/SignUpService';
 
-import InvalidSignUpInput from '../../exceptions/signup/InvalidSignUpInput';
+import InvalidSignUpInput from '../exceptions/signup/InvalidSignUpInput';
 
 const router = express.Router();
 

--- a/src/routes/userRoutes.test.js
+++ b/src/routes/userRoutes.test.js
@@ -2,17 +2,17 @@ import request from 'supertest';
 
 import context from 'jest-plugin-context';
 
-import server from '../../../app';
+import server from '../../app';
 
 jest.mock('reflect-metadata', () => jest.fn());
-jest.mock('../../data-source', () => ({
+jest.mock('../data-source', () => ({
   initialize: jest.fn(),
 }));
 
 const signUp = jest.fn();
 
 jest.mock(
-  '../../services/user/SignUpService',
+  '../services/user/SignUpService',
   () => ({
     signUpService: {
       signUp: () => signUp(),


### PR DESCRIPTION
- 모든 route 스크립트를 routes 디렉토리 바로 하위에 배치
- 각 route가 이미 특정 도메인에 대한 Endpoint를 포함하므로, 하위 디렉토리로 추가 식별하지 않고 각 route로 식별